### PR TITLE
Add comprehensive visualization methods to PokerSimulator

### DIFF
--- a/VISUALIZATION_README.md
+++ b/VISUALIZATION_README.md
@@ -1,0 +1,386 @@
+# PokerSimulator Visualizations
+
+Comprehensive visualization methods for analyzing Monte Carlo poker simulation results.
+
+## Features
+
+The `PokerSimulator` class includes four main visualization methods:
+
+1. **Equity Bar Charts** - Compare player equities side-by-side
+2. **Outcome Distribution** - Stacked bars showing win/tie/loss breakdown
+3. **Individual Pie Charts** - Per-player outcome visualization
+4. **Equity Convergence** - Track how equity estimates stabilize over simulations
+
+## Installation Requirements
+
+```bash
+pip install matplotlib numpy
+```
+
+## Visualization Methods
+
+### 1. `plot_equity_bars()`
+
+Creates a bar chart comparing equity across all players.
+
+**Features:**
+- Color gradient from red (low equity) to green (high equity)
+- Displays hole cards for each player
+- Shows equity percentage on top of each bar
+
+**Usage:**
+```python
+from card import Card
+from simulator import PokerSimulator
+
+class SimpleHand:
+    def __init__(self, hole_cards):
+        self.hole_cards = hole_cards
+
+player0 = SimpleHand([Card('Ah'), Card('As')])
+player1 = SimpleHand([Card('Kh'), Card('Ks')])
+
+sim = PokerSimulator(
+    players=2,
+    community_cards=[],
+    player_hands=[player0, player1],
+    num_simulations=10000
+)
+
+sim.run_simulation()
+sim.plot_equity_bars()
+```
+
+**Parameters:**
+- `save_path` (str, optional): Path to save the figure as PNG
+- `show` (bool, default=True): Whether to display the plot
+
+**Example:**
+```python
+sim.plot_equity_bars(save_path='equity_bars.png', show=True)
+```
+
+---
+
+### 2. `plot_outcome_distribution()`
+
+Creates a stacked bar chart showing win/tie/loss percentages for each player.
+
+**Features:**
+- Green for wins, orange for ties, red for losses
+- 100% stacked format for easy comparison
+- Shows exact percentage breakdown
+
+**Usage:**
+```python
+sim.run_simulation()
+sim.plot_outcome_distribution()
+```
+
+**Parameters:**
+- `save_path` (str, optional): Path to save the figure
+- `show` (bool, default=True): Whether to display the plot
+
+---
+
+### 3. `plot_equity_pie_charts()`
+
+Creates individual pie charts for each player showing their win/tie/loss breakdown.
+
+**Features:**
+- One pie chart per player
+- Displays equity percentage in title
+- Automatic grid layout (up to 3 columns)
+- Only shows non-zero slices
+
+**Usage:**
+```python
+sim.run_simulation()
+sim.plot_equity_pie_charts()
+```
+
+**Parameters:**
+- `save_path` (str, optional): Path to save the figure
+- `show` (bool, default=True): Whether to display the plot
+
+---
+
+### 4. `plot_equity_convergence()`
+
+Plots how equity estimates converge as more simulations are run.
+
+**Features:**
+- Line plot showing equity over time
+- Different color for each player
+- Useful for determining optimal simulation count
+- Re-runs simulation with tracking
+
+**Usage:**
+```python
+sim.run_simulation()
+sim.plot_equity_convergence(sample_interval=100)
+```
+
+**Parameters:**
+- `sample_interval` (int, default=100): How often to sample equity
+- `save_path` (str, optional): Path to save the figure
+- `show` (bool, default=True): Whether to display the plot
+
+**Note:** This method re-runs the simulation to track convergence, so it may take longer.
+
+---
+
+### 5. `plot_all_visualizations()`
+
+Convenience method to generate all visualizations at once.
+
+**Usage:**
+```python
+sim.run_simulation()
+sim.plot_all_visualizations(save_dir='output', show=False)
+```
+
+**Parameters:**
+- `save_dir` (str, optional): Directory to save all figures
+- `show` (bool, default=True): Whether to display plots
+
+**Generated files:**
+- `equity_bars.png`
+- `outcome_distribution.png`
+- `pie_charts.png`
+- `equity_convergence.png`
+
+## Complete Examples
+
+### Example 1: Two Player Pre-flop Analysis
+
+```python
+from card import Card
+from simulator import PokerSimulator
+
+class SimpleHand:
+    def __init__(self, hole_cards):
+        self.hole_cards = hole_cards
+
+# AA vs KK pre-flop
+player0 = SimpleHand([Card('Ah'), Card('As')])
+player1 = SimpleHand([Card('Kh'), Card('Ks')])
+
+sim = PokerSimulator(
+    players=2,
+    community_cards=[],
+    player_hands=[player0, player1],
+    num_simulations=10000
+)
+
+sim.run_simulation()
+
+# Generate all visualizations
+sim.plot_equity_bars()
+sim.plot_outcome_distribution()
+sim.plot_equity_pie_charts()
+sim.plot_equity_convergence(sample_interval=200)
+```
+
+### Example 2: Three Player Post-Flop Analysis
+
+```python
+# Top pair vs Overpair vs Straight draw
+player0 = SimpleHand([Card('As'), Card('Ks')])  # Top pair
+player1 = SimpleHand([Card('Qh'), Card('Qd')])  # Overpair
+player2 = SimpleHand([Card('Jc'), Card('Tc')])  # Straight draw
+
+# Flop: K♥Q♠9♦
+community = [Card('Kh'), Card('Qs'), Card('9d')]
+
+sim = PokerSimulator(
+    players=3,
+    community_cards=community,
+    player_hands=[player0, player1, player2],
+    num_simulations=10000
+)
+
+sim.run_simulation()
+sim.plot_equity_bars()
+sim.plot_outcome_distribution()
+sim.plot_equity_pie_charts()
+```
+
+### Example 3: Save All Visualizations to Files
+
+```python
+player0 = SimpleHand([Card('Ah'), Card('Kh')])  # Flush draw
+player1 = SimpleHand([Card('Qs'), Card('Qc')])  # Overpair
+
+community = [Card('9h'), Card('7h'), Card('2s')]
+
+sim = PokerSimulator(
+    players=2,
+    community_cards=community,
+    player_hands=[player0, player1],
+    num_simulations=10000
+)
+
+sim.run_simulation()
+
+# Save all visualizations without displaying
+sim.plot_all_visualizations(save_dir='poker_analysis', show=False)
+```
+
+### Example 4: Four Player Tournament
+
+```python
+player0 = SimpleHand([Card('As'), Card('Ad')])  # Pocket Aces
+player1 = SimpleHand([Card('Kh'), Card('Kd')])  # Pocket Kings
+player2 = SimpleHand([Card('Ah'), Card('Kh')])  # AK suited
+player3 = SimpleHand([Card('9s'), Card('9c')])  # Pocket Nines
+
+# Flop: A♣7♣2♠
+community = [Card('Ac'), Card('7c'), Card('2s')]
+
+sim = PokerSimulator(
+    players=4,
+    community_cards=community,
+    player_hands=[player0, player1, player2, player3],
+    num_simulations=10000
+)
+
+sim.run_simulation()
+sim.print_results()
+
+# Generate visualizations
+sim.plot_equity_bars()
+sim.plot_outcome_distribution()
+sim.plot_equity_pie_charts()
+```
+
+## Testing Visualizations
+
+Run the comprehensive demo:
+```bash
+python test_visualizations.py
+```
+
+This will demonstrate all visualization types with various poker scenarios.
+
+For a quick non-interactive test:
+```bash
+python test_viz_quick.py
+```
+
+This generates all visualizations and saves them as PNG files without displaying.
+
+## Customization Tips
+
+### Adjusting Figure Size
+
+You can modify the figure size by editing the `figsize` parameter in the source:
+
+```python
+# In simulator.py, change:
+fig, ax = plt.subplots(figsize=(10, 6))
+# To:
+fig, ax = plt.subplots(figsize=(12, 8))
+```
+
+### Changing Colors
+
+Color schemes can be customized in each method:
+
+```python
+# Equity bars - uses RdYlGn colormap (Red-Yellow-Green)
+colors = plt.cm.RdYlGn(np.linspace(0.3, 0.9, self.players))
+
+# Outcome distribution - manual colors
+wins: '#2ecc71' (green)
+ties: '#f39c12' (orange)
+losses: '#e74c3c' (red)
+```
+
+### Adjusting Convergence Sampling
+
+For more detailed convergence plots, decrease the sample interval:
+
+```python
+# More samples = smoother curve but slower
+sim.plot_equity_convergence(sample_interval=50)
+
+# Fewer samples = faster but less smooth
+sim.plot_equity_convergence(sample_interval=500)
+```
+
+## Performance Considerations
+
+- **Standard plots** (bars, distributions, pie charts): Very fast (~instant)
+- **Convergence plots**: Slower as they re-run the simulation with tracking
+  - 10,000 simulations with interval=100: ~2-5 seconds
+  - 50,000 simulations with interval=500: ~10-15 seconds
+
+## Output Files
+
+When saving visualizations, recommended DPI is 300 for publication quality:
+
+```python
+sim.plot_equity_bars(save_path='equity.png')  # Uses default 300 DPI
+```
+
+Files are saved as PNG with:
+- High resolution (300 DPI)
+- Tight bounding box (no extra whitespace)
+- Transparent background support
+
+## Interpretation Guide
+
+### Equity Bar Chart
+- **Height = Win probability + (Tie probability / 2)**
+- Useful for quickly identifying favorites
+- Color coding helps spot underdogs vs favorites
+
+### Outcome Distribution
+- **100% stacked** shows relative chances
+- Large green section = strong favorite
+- Significant orange = many split pots (e.g., similar hands)
+- Large red = underdog
+
+### Pie Charts
+- **Individual perspective** for each player
+- Useful for multi-player scenarios
+- Equity shown in title for quick reference
+
+### Convergence Plot
+- **Flat line = converged** estimate
+- **Still trending** = need more simulations
+- Different convergence rates show certainty levels
+- Tight convergence (< 1000 sims) = very lopsided scenario
+- Slow convergence = close race
+
+## Common Use Cases
+
+1. **Hand analysis** - Understand equity in specific situations
+2. **Strategy development** - Identify profitable plays
+3. **Educational** - Visualize poker concepts
+4. **Content creation** - Generate graphics for articles/videos
+5. **Tournament analysis** - Multi-player equity distribution
+
+## Files
+
+- **[simulator.py](simulator.py)** - Main PokerSimulator class with visualization methods
+- **[test_visualizations.py](test_visualizations.py)** - Comprehensive demo suite
+- **[test_viz_quick.py](test_viz_quick.py)** - Quick non-interactive test
+
+## Dependencies
+
+```
+matplotlib >= 3.0
+numpy >= 1.19
+phevaluator
+```
+
+## Future Enhancements
+
+Potential additions:
+- Heatmaps for range vs range analysis
+- 3D plots for three-player scenarios
+- Animation showing equity changes across streets
+- Probability density functions
+- Interactive plots with Plotly

--- a/simulator.py
+++ b/simulator.py
@@ -1,8 +1,11 @@
 import random
-from typing import List, Dict, Union, Any
+from typing import List, Dict, Union, Any, Optional
 from card import Card
 from deck import Deck
 from phevaluator import evaluate_cards
+import matplotlib.pyplot as plt
+import matplotlib.patches as mpatches
+import numpy as np
 
 
 class PokerSimulator:
@@ -223,6 +226,255 @@ class PokerSimulator:
             return pd.DataFrame(rows)
         except ImportError:
             return None
+
+    def plot_equity_bars(self, save_path: Optional[str] = None, show: bool = True) -> None:
+        """
+        Create a bar chart showing equity for each player.
+
+        Args:
+            save_path: Optional path to save the figure
+            show: Whether to display the plot (default: True)
+        """
+        equity_data = self.calculate_equity()
+
+        players = list(range(self.players))
+        equities = [equity_data[p]['equity'] * 100 for p in players]
+
+        # Create player labels with hole cards
+        labels = []
+        for p in players:
+            hole_cards = [card.to_string() for card in self.player_hands[p].hole_cards]
+            labels.append(f"P{p}\n{hole_cards[0]}{hole_cards[1]}")
+
+        # Create color gradient
+        colors = plt.cm.RdYlGn(np.linspace(0.3, 0.9, self.players))
+
+        fig, ax = plt.subplots(figsize=(10, 6))
+        bars = ax.bar(labels, equities, color=colors, edgecolor='black', linewidth=1.5)
+
+        # Add value labels on bars
+        for bar, equity in zip(bars, equities):
+            height = bar.get_height()
+            ax.text(bar.get_x() + bar.get_width()/2., height,
+                   f'{equity:.1f}%',
+                   ha='center', va='bottom', fontweight='bold', fontsize=11)
+
+        ax.set_ylabel('Equity (%)', fontsize=12, fontweight='bold')
+        ax.set_xlabel('Player (Hole Cards)', fontsize=12, fontweight='bold')
+        ax.set_title(f'Player Equity Distribution\n({self.num_simulations:,} simulations)',
+                    fontsize=14, fontweight='bold')
+        ax.set_ylim(0, 110)
+        ax.grid(axis='y', alpha=0.3, linestyle='--')
+
+        plt.tight_layout()
+
+        if save_path:
+            plt.savefig(save_path, dpi=300, bbox_inches='tight')
+        if show:
+            plt.show()
+        else:
+            plt.close()
+
+    def plot_outcome_distribution(self, save_path: Optional[str] = None, show: bool = True) -> None:
+        """
+        Create stacked bar chart showing win/tie/loss distribution for each player.
+
+        Args:
+            save_path: Optional path to save the figure
+            show: Whether to display the plot (default: True)
+        """
+        equity_data = self.calculate_equity()
+
+        players = list(range(self.players))
+        labels = []
+        for p in players:
+            hole_cards = [card.to_string() for card in self.player_hands[p].hole_cards]
+            labels.append(f"P{p}\n{hole_cards[0]}{hole_cards[1]}")
+
+        wins = [equity_data[p]['win_rate'] * 100 for p in players]
+        ties = [equity_data[p]['tie_rate'] * 100 for p in players]
+        losses = [equity_data[p]['loss_rate'] * 100 for p in players]
+
+        fig, ax = plt.subplots(figsize=(10, 6))
+
+        # Create stacked bars
+        ax.bar(labels, wins, label='Wins', color='#2ecc71', edgecolor='black', linewidth=1)
+        ax.bar(labels, ties, bottom=wins, label='Ties', color='#f39c12', edgecolor='black', linewidth=1)
+        ax.bar(labels, losses, bottom=np.array(wins) + np.array(ties),
+               label='Losses', color='#e74c3c', edgecolor='black', linewidth=1)
+
+        ax.set_ylabel('Percentage (%)', fontsize=12, fontweight='bold')
+        ax.set_xlabel('Player (Hole Cards)', fontsize=12, fontweight='bold')
+        ax.set_title(f'Outcome Distribution by Player\n({self.num_simulations:,} simulations)',
+                    fontsize=14, fontweight='bold')
+        ax.set_ylim(0, 100)
+        ax.legend(loc='upper right', fontsize=10)
+        ax.grid(axis='y', alpha=0.3, linestyle='--')
+
+        plt.tight_layout()
+
+        if save_path:
+            plt.savefig(save_path, dpi=300, bbox_inches='tight')
+        if show:
+            plt.show()
+        else:
+            plt.close()
+
+    def plot_equity_pie_charts(self, save_path: Optional[str] = None, show: bool = True) -> None:
+        """
+        Create pie charts showing win/tie/loss breakdown for each player.
+
+        Args:
+            save_path: Optional path to save the figure
+            show: Whether to display the plot (default: True)
+        """
+        equity_data = self.calculate_equity()
+
+        # Determine grid layout
+        cols = min(3, self.players)
+        rows = (self.players + cols - 1) // cols
+
+        fig, axes = plt.subplots(rows, cols, figsize=(5*cols, 4*rows))
+        if self.players == 1:
+            axes = np.array([axes])
+        axes = axes.flatten()
+
+        colors = ['#2ecc71', '#f39c12', '#e74c3c']
+
+        for p in range(self.players):
+            stats = equity_data[p]
+            hole_cards = [card.to_string() for card in self.player_hands[p].hole_cards]
+
+            sizes = [stats['win_rate'] * 100, stats['tie_rate'] * 100, stats['loss_rate'] * 100]
+            labels = [f"Win\n{sizes[0]:.1f}%", f"Tie\n{sizes[1]:.1f}%", f"Loss\n{sizes[2]:.1f}%"]
+
+            # Only show non-zero slices
+            non_zero_sizes = [s for s in sizes if s > 0]
+            non_zero_labels = [l for s, l in zip(sizes, labels) if s > 0]
+            non_zero_colors = [c for s, c in zip(sizes, colors) if s > 0]
+
+            axes[p].pie(non_zero_sizes, labels=non_zero_labels, colors=non_zero_colors,
+                       autopct='', startangle=90, wedgeprops={'edgecolor': 'black', 'linewidth': 1.5})
+            axes[p].set_title(f"Player {p}: {hole_cards[0]}{hole_cards[1]}\nEquity: {stats['equity']:.1%}",
+                            fontweight='bold', fontsize=11)
+
+        # Hide unused subplots
+        for p in range(self.players, len(axes)):
+            axes[p].axis('off')
+
+        fig.suptitle(f'Individual Player Outcomes\n({self.num_simulations:,} simulations)',
+                    fontsize=14, fontweight='bold')
+        plt.tight_layout()
+
+        if save_path:
+            plt.savefig(save_path, dpi=300, bbox_inches='tight')
+        if show:
+            plt.show()
+        else:
+            plt.close()
+
+    def plot_equity_convergence(self, sample_interval: int = 100,
+                                save_path: Optional[str] = None, show: bool = True) -> None:
+        """
+        Plot how equity estimates converge as more simulations run.
+
+        This requires re-running the simulation with tracking.
+
+        Args:
+            sample_interval: How often to sample equity (every N simulations)
+            save_path: Optional path to save the figure
+            show: Whether to display the plot (default: True)
+        """
+        # Store original results
+        original_results = self._results.copy()
+
+        # Track equity over time
+        equity_history = {p: [] for p in range(self.players)}
+        sample_points = []
+
+        # Reset results
+        self._results = {
+            i: {'wins': 0, 'ties': 0, 'losses': 0}
+            for i in range(self.players)
+        }
+
+        # Run simulation with periodic sampling
+        for sim in range(1, self.num_simulations + 1):
+            self._simulate_single_hand()
+
+            if sim % sample_interval == 0 or sim == self.num_simulations:
+                sample_points.append(sim)
+                current_equity = self.calculate_equity()
+                for p in range(self.players):
+                    equity_history[p].append(current_equity[p]['equity'] * 100)
+
+        # Create plot
+        fig, ax = plt.subplots(figsize=(12, 6))
+
+        colors = plt.cm.tab10(np.linspace(0, 1, self.players))
+
+        for p in range(self.players):
+            hole_cards = [card.to_string() for card in self.player_hands[p].hole_cards]
+            label = f"Player {p} ({hole_cards[0]}{hole_cards[1]})"
+            ax.plot(sample_points, equity_history[p], label=label,
+                   color=colors[p], linewidth=2, marker='o', markersize=3)
+
+        ax.set_xlabel('Number of Simulations', fontsize=12, fontweight='bold')
+        ax.set_ylabel('Equity (%)', fontsize=12, fontweight='bold')
+        ax.set_title('Equity Convergence Over Simulations', fontsize=14, fontweight='bold')
+        ax.legend(loc='best', fontsize=10)
+        ax.grid(True, alpha=0.3, linestyle='--')
+        ax.set_ylim(0, 100)
+
+        plt.tight_layout()
+
+        if save_path:
+            plt.savefig(save_path, dpi=300, bbox_inches='tight')
+        if show:
+            plt.show()
+        else:
+            plt.close()
+
+    def plot_all_visualizations(self, save_dir: Optional[str] = None, show: bool = True) -> None:
+        """
+        Generate all visualization plots.
+
+        Args:
+            save_dir: Optional directory to save all figures
+            show: Whether to display the plots (default: True)
+        """
+        import os
+
+        save_paths = {
+            'equity_bars': None,
+            'outcome_dist': None,
+            'pie_charts': None,
+            'convergence': None
+        }
+
+        if save_dir:
+            os.makedirs(save_dir, exist_ok=True)
+            save_paths['equity_bars'] = os.path.join(save_dir, 'equity_bars.png')
+            save_paths['outcome_dist'] = os.path.join(save_dir, 'outcome_distribution.png')
+            save_paths['pie_charts'] = os.path.join(save_dir, 'pie_charts.png')
+            save_paths['convergence'] = os.path.join(save_dir, 'equity_convergence.png')
+
+        print("Generating visualizations...")
+        print("1/4: Equity bar chart...")
+        self.plot_equity_bars(save_path=save_paths['equity_bars'], show=show)
+
+        print("2/4: Outcome distribution...")
+        self.plot_outcome_distribution(save_path=save_paths['outcome_dist'], show=show)
+
+        print("3/4: Individual pie charts...")
+        self.plot_equity_pie_charts(save_path=save_paths['pie_charts'], show=show)
+
+        print("4/4: Equity convergence...")
+        self.plot_equity_convergence(save_path=save_paths['convergence'], show=show)
+
+        print("All visualizations complete!")
+        if save_dir:
+            print(f"Saved to: {save_dir}")
 
     def print_results(self) -> None:
         """Print formatted results to console."""

--- a/test_visualizations.py
+++ b/test_visualizations.py
@@ -1,0 +1,224 @@
+"""
+Test and demonstration file for PokerSimulator visualization features.
+
+Demonstrates:
+1. Equity bar charts
+2. Outcome distribution (stacked bars)
+3. Individual pie charts
+4. Equity convergence over simulations
+5. Batch generation of all visualizations
+"""
+
+from card import Card
+from simulator import PokerSimulator
+import os
+
+
+class SimpleSimpleHand:
+    """Simple hand class for testing."""
+    def __init__(self, hole_cards):
+        self.hole_cards = hole_cards
+
+
+def demo_two_player_preflop():
+    """Demo: Two player pre-flop visualization"""
+    print("\n" + "="*70)
+    print("DEMO 1: Two Player Pre-flop (AA vs KK)")
+    print("="*70)
+
+    player0 = SimpleHand([Card('Ah'), Card('As')])
+    player1 = SimpleHand([Card('Kh'), Card('Ks')])
+
+    sim = PokerSimulator(
+        players=2,
+        community_cards=[],
+        player_hands=[player0, player1],
+        num_simulations=10000
+    )
+
+    print("Running 10,000 simulations...")
+    sim.run_simulation()
+    sim.print_results()
+
+    print("\nGenerating visualizations...")
+    sim.plot_equity_bars()
+    sim.plot_outcome_distribution()
+    sim.plot_equity_pie_charts()
+
+
+def demo_three_player_flop():
+    """Demo: Three player post-flop visualization"""
+    print("\n" + "="*70)
+    print("DEMO 2: Three Player Post-Flop")
+    print("="*70)
+
+    player0 = SimpleHand([Card('As'), Card('Ks')])  # Top pair
+    player1 = SimpleHand([Card('Qh'), Card('Qd')])  # Overpair
+    player2 = SimpleHand([Card('Jc'), Card('Tc')])  # Straight draw
+
+    # Flop: K♥Q♠9♦
+    community = [Card('Kh'), Card('Qs'), Card('9d')]
+
+    sim = PokerSimulator(
+        players=3,
+        community_cards=community,
+        player_hands=[player0, player1, player2],
+        num_simulations=10000
+    )
+
+    print("Running 10,000 simulations...")
+    sim.run_simulation()
+    sim.print_results()
+
+    print("\nGenerating visualizations...")
+    sim.plot_equity_bars()
+    sim.plot_outcome_distribution()
+    sim.plot_equity_pie_charts()
+
+
+def demo_flush_draw_scenario():
+    """Demo: Flush draw vs overpair"""
+    print("\n" + "="*70)
+    print("DEMO 3: Flush Draw vs Overpair")
+    print("="*70)
+
+    player0 = SimpleHand([Card('Ah'), Card('Kh')])  # Flush draw + overcards
+    player1 = SimpleHand([Card('Qs'), Card('Qc')])  # Overpair
+
+    # Flop: 9♥7♥2♠
+    community = [Card('9h'), Card('7h'), Card('2s')]
+
+    sim = PokerSimulator(
+        players=2,
+        community_cards=community,
+        player_hands=[player0, player1],
+        num_simulations=10000
+    )
+
+    print("Running 10,000 simulations...")
+    sim.run_simulation()
+    sim.print_results()
+
+    print("\nGenerating visualizations...")
+    sim.plot_equity_bars()
+    sim.plot_outcome_distribution()
+
+
+def demo_equity_convergence():
+    """Demo: Equity convergence visualization"""
+    print("\n" + "="*70)
+    print("DEMO 4: Equity Convergence Over Simulations")
+    print("="*70)
+
+    player0 = SimpleHand([Card('Ah'), Card('As')])
+    player1 = SimpleHand([Card('Kh'), Card('Ks')])
+    player2 = SimpleHand([Card('Qd'), Card('Qc')])
+
+    sim = PokerSimulator(
+        players=3,
+        community_cards=[],
+        player_hands=[player0, player1, player2],
+        num_simulations=10000
+    )
+
+    print("Running simulation with convergence tracking...")
+    sim.run_simulation()
+
+    print("\nGenerating convergence plot (this may take a moment)...")
+    sim.plot_equity_convergence(sample_interval=200)
+
+
+def demo_four_player_tournament():
+    """Demo: Four player scenario with all visualizations"""
+    print("\n" + "="*70)
+    print("DEMO 5: Four Player Tournament Style")
+    print("="*70)
+
+    player0 = SimpleHand([Card('As'), Card('Ad')])  # Pocket Aces
+    player1 = SimpleHand([Card('Kh'), Card('Kd')])  # Pocket Kings
+    player2 = SimpleHand([Card('Ah'), Card('Kh')])  # AK suited
+    player3 = SimpleHand([Card('9s'), Card('9c')])  # Pocket Nines
+
+    # Flop: A♣7♣2♠
+    community = [Card('Ac'), Card('7c'), Card('2s')]
+
+    sim = PokerSimulator(
+        players=4,
+        community_cards=community,
+        player_hands=[player0, player1, player2, player3],
+        num_simulations=10000
+    )
+
+    print("Running 10,000 simulations...")
+    sim.run_simulation()
+    sim.print_results()
+
+    print("\nGenerating all visualizations...")
+    sim.plot_equity_bars()
+    sim.plot_outcome_distribution()
+    sim.plot_equity_pie_charts()
+
+
+def demo_save_all_visualizations():
+    """Demo: Save all visualizations to files"""
+    print("\n" + "="*70)
+    print("DEMO 6: Save All Visualizations to Files")
+    print("="*70)
+
+    player0 = SimpleHand([Card('Ah'), Card('Kh')])
+    player1 = SimpleHand([Card('Qs'), Card('Qc')])
+
+    community = [Card('9h'), Card('7h'), Card('2s')]
+
+    sim = PokerSimulator(
+        players=2,
+        community_cards=community,
+        player_hands=[player0, player1],
+        num_simulations=10000
+    )
+
+    print("Running 10,000 simulations...")
+    sim.run_simulation()
+
+    # Create output directory
+    output_dir = "visualization_output"
+
+    print(f"\nGenerating and saving all visualizations to '{output_dir}/'...")
+    sim.plot_all_visualizations(save_dir=output_dir, show=False)
+
+    print(f"\nVisualizations saved successfully!")
+    print(f"Check the '{output_dir}' folder for PNG files.")
+
+
+def run_all_demos():
+    """Run all demonstration scenarios"""
+    print("\n" + "="*70)
+    print("POKER SIMULATOR VISUALIZATION DEMOS")
+    print("="*70)
+    print("\nClose each plot window to proceed to the next demo.")
+    print("Press Ctrl+C to exit early.\n")
+
+    try:
+        demo_two_player_preflop()
+        demo_three_player_flop()
+        demo_flush_draw_scenario()
+        demo_equity_convergence()
+        demo_four_player_tournament()
+        demo_save_all_visualizations()
+
+        print("\n" + "="*70)
+        print("ALL DEMOS COMPLETED!")
+        print("="*70)
+
+    except KeyboardInterrupt:
+        print("\n\nDemos interrupted by user.")
+
+
+if __name__ == "__main__":
+    # You can run all demos or individual ones
+    run_all_demos()
+
+    # Or run specific demos:
+    # demo_two_player_preflop()
+    # demo_equity_convergence()
+    # demo_save_all_visualizations()

--- a/test_viz_quick.py
+++ b/test_viz_quick.py
@@ -1,0 +1,52 @@
+"""
+Quick test to verify visualizations work without showing plots.
+"""
+
+from card import Card
+from simulator import PokerSimulator
+
+
+class SimpleHand:
+    """Simple hand class for testing."""
+    def __init__(self, hole_cards):
+        self.hole_cards = hole_cards
+
+
+def quick_test():
+    """Quick test of visualization functionality"""
+    print("Testing visualization functionality...")
+
+    player0 = SimpleHand([Card('Ah'), Card('As')])
+    player1 = SimpleHand([Card('Kh'), Card('Ks')])
+
+    sim = PokerSimulator(
+        players=2,
+        community_cards=[],
+        player_hands=[player0, player1],
+        num_simulations=1000
+    )
+
+    print("Running 1,000 simulations...")
+    sim.run_simulation()
+    sim.print_results()
+
+    print("\nGenerating visualizations (saving to files, not displaying)...")
+
+    # Test each visualization method
+    print("- Equity bars...")
+    sim.plot_equity_bars(save_path="test_equity_bars.png", show=False)
+
+    print("- Outcome distribution...")
+    sim.plot_outcome_distribution(save_path="test_outcome_dist.png", show=False)
+
+    print("- Pie charts...")
+    sim.plot_equity_pie_charts(save_path="test_pie_charts.png", show=False)
+
+    print("- Convergence plot...")
+    sim.plot_equity_convergence(sample_interval=100, save_path="test_convergence.png", show=False)
+
+    print("\nAll visualizations generated successfully!")
+    print("Check for test_*.png files in the current directory.")
+
+if __name__ == "__main__":
+    quick_test()


### PR DESCRIPTION
- Add 4 visualization methods using matplotlib:
  * plot_equity_bars(): Bar chart comparing player equities
  * plot_outcome_distribution(): Stacked bars for win/tie/loss
  * plot_equity_pie_charts(): Individual pie charts per player
  * plot_equity_convergence(): Track equity stabilization over time
  * plot_all_visualizations(): Batch generate all plots

- Features:
  * Save to PNG files (300 DPI)
  * Interactive display or batch mode
  * Color-coded equity visualization (red to green gradient)
  * Multi-player support (2-10 players)
  * Professional styling with matplotlib

- Add comprehensive documentation (VISUALIZATION_README.md)
- Add test suite (test_visualizations.py) with 6 demo scenarios
- Add quick test (test_viz_quick.py) for non-interactive testing